### PR TITLE
Update dsiwareInjection.html

### DIFF
--- a/dsiwareInjection.html
+++ b/dsiwareInjection.html
@@ -77,7 +77,7 @@
           </ul>
           <li>Exit System Settings and start your game</li>
           <ul>
-            <li>You should be greeted by a white screen complaining that it could not load a file.
+            <li>You should be greeted by a white screen complaining that it could not load a file (or solid light-green screens, top and bottom, with no text at all). 
               <strong>this is the intended result</strong>
             </li>
             <li>


### PR DESCRIPTION
This reflects the new changes in the Jenkin's site. There are new 16KB saves files for sudoku that use @Fincs minitwlpayload that do not inform of any missing boot.nds files. This is done, in part, to make the payload as small as possible. With 16KB public.savs, dsiware injection with sukoku compatibility is increased by a factor of five. 83% of US dsiware, and 86% of EU dsiware titles are now supported.