### PR TITLE
Update b9sTool instructions for 5.0.0

### DIFF
--- a/injection/index.html
+++ b/injection/index.html
@@ -127,10 +127,10 @@
           <ul>
             <li>You may need to force power off by holding the power button</li>
           </ul>
-          <li>Boot up your 3DS while holding (Select) to launch the Luma3DS configuration menu
+          <li>Boot up your 3DS to launch the Luma3DS configuration menu
             <ul>
               <li>If your 3DS boots normally to the HOME Menu then boot9strap did not install correctly. Please follow Point
-                C from
+                B from
                 <a class="a-table" target="_blank" href="https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md">this guide</a>
               </li>
             </ul>


### PR DESCRIPTION
b9sTool 5.0.0 update has updated troubleshooting - there is no C now, just A and B. 
There's also no need to hold SELECT after b9s is installed, b9sTool deletes that file if it exists.